### PR TITLE
Support image in zip, normal images, and network zip

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.appsubaruod.comicviewer">
+    <uses-permission android:name="android.permission.MANAGE_DOCUMENTS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/appsubaruod/comicviewer/managers/NavigationItemInteraction.java
+++ b/app/src/main/java/com/appsubaruod/comicviewer/managers/NavigationItemInteraction.java
@@ -1,8 +1,12 @@
 package com.appsubaruod.comicviewer.managers;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.MenuItem;
 
@@ -43,7 +47,9 @@ public class NavigationItemInteraction {
 
         switch (id) {
             case R.id.nav_openbook:
-                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+
+
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
                 intent.setType("*/*");
                 EventBus.getDefault().post(new RequestActivityIntentEvent(intent, CHOSE_FILE_CODE));
                 break;

--- a/app/src/main/java/com/appsubaruod/comicviewer/model/ComicModel.java
+++ b/app/src/main/java/com/appsubaruod/comicviewer/model/ComicModel.java
@@ -10,19 +10,11 @@ import com.appsubaruod.comicviewer.utils.messages.SetImageEvent;
 
 import org.greenrobot.eventbus.EventBus;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 /**
  * Created by s-yamada on 2017/03/28.
@@ -35,17 +27,35 @@ public class ComicModel {
     private Map<Integer, File> mFileMap = new HashMap<>();
 
     private final String LOG_TAG = "ComicModel";
-    private final Context mContext;
-    private final File mFileDir;
     private final Executor mWorkerThread = Executors.newSingleThreadExecutor();
 
-    private static final int BUFFER = 512;
-    private static final int TOOBIG = 0x6400000; // maximum file size : 100MB
-    private static final int TOOMANY = 10000;     // maximum file entries
+    private FileOperator mFileOperator;
+
+    private FileOperator.OnFileCopy mOnFileCopy = new FileOperator.OnFileCopy() {
+        @Override
+        public void onCopiedSingleFile(int fileCount, File outFile, int unpackedBytes) {
+            storeFileList(fileCount, outFile);
+            setMaxPageIndex(fileCount);
+
+            if (fileCount == 1) {
+                mPageIndex = 1;
+                // call postSticky, so as not to drop sending event during fragment transition
+                EventBus.getDefault().postSticky(new SetImageEvent(mPageIndex, obtainFile(mPageIndex)));
+                // notify book is opened
+                EventBus.getDefault().postSticky(new BookOpenedEvent());
+            }
+        }
+
+        @Override
+        public void onCopyCompleted(int maxFileCount) {
+            // Send notification including maxpage info
+            EventBus.getDefault().post(new LoadCompleteEvent(maxFileCount));
+        }
+    };
 
     private ComicModel(Context context) {
-        mContext = context;
-        mFileDir = mContext.getFilesDir();
+        mFileOperator = new FileOperator(context);
+        mFileOperator.registerCallback(mOnFileCopy);
     }
 
     public static ComicModel getInstance(Context mContext) {
@@ -68,10 +78,24 @@ public class ComicModel {
             @Override
             public void run() {
                 Log.d(LOG_TAG, uri.toString());
-                EventBus.getDefault().postSticky(new BookOpenedEvent());
-                unpackZip(uri);
+
+                copyToAppStorage(uri);
             }
         });
+    }
+
+    private void copyToAppStorage(Uri uri) {
+        initialize();
+        if (uri.getPath().contains(".zip")) {
+            // maybe zip file
+            mFileOperator.unpackZip(uri);
+        } else if (uri.getPath().endsWith(".png")
+                || uri.getPath().endsWith(".jpg")
+                || uri.getPath().endsWith(".jpeg")
+                || uri.getPath().endsWith(".gif")) {
+            // image file
+            mFileOperator.copyImageFiles(uri);
+        }
     }
 
     public void readNextPage() {
@@ -128,81 +152,9 @@ public class ComicModel {
         });
     }
 
-    private String validateFilename(String filename, String intendedDir) throws IOException {
-        File f = new File(filename);
-        String canonicalPath = f.getCanonicalPath();
 
-        File iD = new File(intendedDir);
-        String canonicalID = iD.getCanonicalPath();
-
-        if (canonicalPath.startsWith(canonicalID)) {
-            return canonicalPath;
-        } else {
-            throw new IllegalStateException("File is outside extraction target directory.");
-        }
-    }
 
     private void unpackZip(Uri zipUri) {
-
-        initialize();
-
-        InputStream is;
-        ZipInputStream zis = null;
-        try {
-            is = mContext.getContentResolver().openInputStream(zipUri);
-            zis = new ZipInputStream(new BufferedInputStream(is));
-            ZipEntry entry;
-            int entries = 0;
-            int total = 0;
-
-            while ((entry = zis.getNextEntry()) != null) {
-                System.out.println("Extracting: " + entry);
-                int count;
-                byte data[] = new byte[BUFFER];
-                // check if file name is valid and size is adequate
-                String name = validateFilename(entry.getName(), ".");
-                File outFile = new File(mFileDir + name);
-                // create parent dirs
-                outFile.getParentFile().mkdirs();
-                FileOutputStream fos = new FileOutputStream(outFile);
-                BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER);
-                while (total <= TOOBIG && (count = zis.read(data, 0, BUFFER)) != -1) {
-                    dest.write(data, 0, count);
-                    total += count;
-                }
-                dest.flush();
-                dest.close();
-                zis.closeEntry();
-
-                entries++;
-                storeFileList(entries, outFile);
-                setMaxPageIndex(entries);
-
-                if (entries == 1) {
-                    mPageIndex = 1;
-                    // call postSticky, so as not to drop sending event during fragment translation
-                    EventBus.getDefault().postSticky(new SetImageEvent(mPageIndex, obtainFile(mPageIndex)));
-                }
-                if (entries > TOOMANY) {
-                    throw new IllegalStateException("Too many files to unzip.");
-                }
-                if (total > TOOBIG) {
-                    throw new IllegalStateException("File being unzipped is too big.");
-                }
-            }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            try {
-                zis.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            // Send notification including maxpage info
-            EventBus.getDefault().post(new LoadCompleteEvent(mMaxPageIndex));
-        }
     }
 
     private void initialize() {

--- a/app/src/main/java/com/appsubaruod/comicviewer/model/FileOperator.java
+++ b/app/src/main/java/com/appsubaruod/comicviewer/model/FileOperator.java
@@ -1,0 +1,136 @@
+package com.appsubaruod.comicviewer.model;
+
+import android.content.Context;
+import android.net.Uri;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.IllegalFormatException;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Created by s-yamada on 2017/04/10.
+ */
+
+public class FileOperator {
+    private Context mContext;
+    private File mFileDir;
+
+    private static final int BUFFER = 512;
+    private static final int TOOBIG = 0x6400000; // maximum file size : 100MB
+    private static final int TOOMANY = 10000;     // maximum file entries
+
+    public FileOperator(Context context) {
+        mContext = context;
+        mFileDir = mContext.getFilesDir();
+    }
+
+    private Set<OnFileCopy> mCallbackSet = new HashSet<>();
+
+    public void registerCallback(OnFileCopy mCallback) {
+        mCallbackSet.add(mCallback);
+    }
+
+    public void unRegisterCallback(OnFileCopy mCallback) {
+        mCallbackSet.remove(mCallback);
+    }
+
+    public void unpackZip(Uri uri) throws IllegalFormatException {
+
+        InputStream is;
+        ZipInputStream zis = null;
+        int entries = 0;
+        try {
+            is = mContext.getContentResolver().openInputStream(uri);
+            zis = new ZipInputStream(new BufferedInputStream(is));
+            ZipEntry entry;
+            int total = 0;
+
+            while ((entry = zis.getNextEntry()) != null) {
+                System.out.println("Extracting: " + entry);
+                int count;
+                byte data[] = new byte[BUFFER];
+                // check if file name is valid and size is adequate
+                String name = validateFilename(entry.getName(), ".");
+                File outFile = new File(mFileDir + name);
+                // create parent dirs
+                outFile.getParentFile().mkdirs();
+                FileOutputStream fos = new FileOutputStream(outFile);
+                BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER);
+                while (total <= TOOBIG && (count = zis.read(data, 0, BUFFER)) != -1) {
+                    dest.write(data, 0, count);
+                    total += count;
+                }
+                dest.flush();
+                dest.close();
+                zis.closeEntry();
+
+                entries++;
+                notifyCopiedSingleFile(entries, outFile, total);
+
+                if (entries > TOOMANY) {
+                    throw new IllegalStateException("Too many files to unzip.");
+                }
+                if (total > TOOBIG) {
+                    throw new IllegalStateException("File being unzipped is too big.");
+                }
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                zis.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            notifyCopyCompleted(entries);
+        }
+
+    }
+
+    public void copyImageFiles(Uri uri) throws IllegalFormatException {
+
+    }
+
+    private void notifyCopiedSingleFile(int fileNumber, File outFile, int unpackedBytes) {
+        for (OnFileCopy item : mCallbackSet) {
+            item.onCopiedSingleFile(fileNumber, outFile, unpackedBytes);
+        }
+    }
+
+    private void notifyCopyCompleted(int maxPage) {
+        for (OnFileCopy item : mCallbackSet) {
+            item.onCopyCompleted(maxPage);
+        }
+    }
+
+    private String validateFilename(String filename, String intendedDir) throws IOException {
+        File f = new File(filename);
+        String canonicalPath = f.getCanonicalPath();
+
+        File iD = new File(intendedDir);
+        String canonicalID = iD.getCanonicalPath();
+
+        if (canonicalPath.startsWith(canonicalID)) {
+            return canonicalPath;
+        } else {
+            throw new IllegalStateException("File is outside extraction target directory.");
+        }
+    }
+
+    protected interface OnFileCopy {
+        void onCopiedSingleFile(int fileCount, File copiedFile, int unpackedBytes);
+        void onCopyCompleted(int maxFileCount);
+    }
+
+}

--- a/app/src/main/java/com/appsubaruod/comicviewer/model/FileOperator.java
+++ b/app/src/main/java/com/appsubaruod/comicviewer/model/FileOperator.java
@@ -1,15 +1,24 @@
 package com.appsubaruod.comicviewer.model;
 
+import android.content.ContentUris;
 import android.content.Context;
+import android.database.Cursor;
 import android.net.Uri;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.util.Log;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
 import java.util.HashSet;
 import java.util.IllegalFormatException;
 import java.util.Set;
@@ -23,6 +32,8 @@ import java.util.zip.ZipInputStream;
 public class FileOperator {
     private Context mContext;
     private File mFileDir;
+
+    private static final String LOG_TAG = FileOperator.class.getName();
 
     private static final int BUFFER = 512;
     private static final int TOOBIG = 0x6400000; // maximum file size : 100MB
@@ -98,8 +109,170 @@ public class FileOperator {
 
     }
 
-    public void copyImageFiles(Uri uri) throws IllegalFormatException {
+    /**
+     * Get a file path from a Uri. This will get the the path for Storage Access
+     * Framework Documents, as well as the _data field for the MediaStore and
+     * other file-based ContentProviders.
+     *
+     * @param uri The Uri to query.
+     * @author paulburke
+     */
+    public String getPath(final Uri uri) {
+        // DocumentProvider
+        if (DocumentsContract.isDocumentUri(mContext, uri)) {
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
 
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+
+                // TODO handle non-primary volumes
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                return getDataColumn(contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
+
+                return getDataColumn(contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            return getDataColumn(uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    public String getDataColumn(Uri uri, String selection,
+                                       String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = mContext.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    public boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    public boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    public boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    public void copyImageFiles(Uri uri) throws IllegalFormatException {
+        File file = new File(getPath(uri));
+        try {
+            int entries = 0;
+            for (File eachFile : file.getParentFile().listFiles(new FileFilter() {
+                @Override
+                public boolean accept(File pathname) {
+                    if (isImageFile(pathname.toString())) {
+                        return true;
+                    }
+                    return false;
+                }
+            })) {
+                Log.d(LOG_TAG, eachFile.getAbsolutePath());
+                File outFile = new File(mFileDir + eachFile.getName());
+                copyImageFile(eachFile, outFile, entries++);
+            }
+            notifyCopyCompleted(entries);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void copyImageFile(File inFile, File outFile, int entry) throws IOException {
+        FileChannel inChannel = new FileInputStream(inFile).getChannel();
+        FileChannel outChannel = new FileOutputStream(outFile).getChannel();
+
+        inChannel.transferTo(0, inChannel.size(), outChannel);
+
+        notifyCopiedSingleFile(entry, outFile, (int) inChannel.size());
+    }
+
+    public boolean isImageFile(String fileName) {
+        String lowerFileName = fileName.toLowerCase();
+        return lowerFileName.endsWith(".png")
+                || lowerFileName.endsWith(".jpg")
+                || lowerFileName.endsWith(".jpeg")
+                || lowerFileName.endsWith(".gif");
     }
 
     private void notifyCopiedSingleFile(int fileNumber, File outFile, int unpackedBytes) {

--- a/app/src/main/java/com/appsubaruod/comicviewer/utils/messages/RequestPermissionEvent.java
+++ b/app/src/main/java/com/appsubaruod/comicviewer/utils/messages/RequestPermissionEvent.java
@@ -1,0 +1,8 @@
+package com.appsubaruod.comicviewer.utils.messages;
+
+/**
+ * Created by s-yamada on 2017/04/12.
+ */
+
+public class RequestPermissionEvent {
+}


### PR DESCRIPTION
- Support image in zip
If user select any image in zip file, the app behaves as if zip is selected

- normal images
If user select normal image, the app searches image files with the same directory and show.
Restriction: it shows the first file in the directory(name order). Does not show selected image.

- network zip
Support zip file that is accessed by other application like DropBox.

- Request runtime permission